### PR TITLE
Fixing requests import

### DIFF
--- a/aws-datadog-controltower.yaml
+++ b/aws-datadog-controltower.yaml
@@ -179,7 +179,7 @@ Resources:
           import os
           import cfnresponse
           import logging
-          from botocore.vendored import requests
+          import requests
 
           logger = logging.getLogger()
           logger.setLevel(logging.INFO)


### PR DESCRIPTION
Fixing exception:
```
/var/runtime/botocore/vendored/requests/api.py:72:
DeprecationWarning: Youare using the put() function from 'botocore.vendored.requests'.
This dependency was removed from Botocore and will be removed from Lambda after 2021-12-01.
https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/.
Install the requests package, 'import requests' directly, and use therequests.put() function instead
```
